### PR TITLE
A bunch of fixes from production usage #4

### DIFF
--- a/Common/Classes/Disposables/BaseDisposable.cs
+++ b/Common/Classes/Disposables/BaseDisposable.cs
@@ -81,7 +81,7 @@ namespace Media.Common
         /// <param name="bd"></param>
         /// <returns></returns>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        internal static long RetrieveState(BaseDisposable bd) { return bd.State; }
+        internal static int RetrieveState(BaseDisposable bd) { return bd.State; }
 
         /// <summary>
         /// Indicates the <see cref=""/>
@@ -89,7 +89,7 @@ namespace Media.Common
         /// <param name="bd"></param>
         /// <returns></returns>
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-        internal static bool IsDestructing(BaseDisposable bd, ref long state) { return (state = RetrieveState(bd)) > Disposed; }
+        internal static bool IsDestructing(BaseDisposable bd, ref int state) { return (state = RetrieveState(bd)) > Disposed; }
 
         /// <summary>
         /// If the sender is of the type <see cref="BaseDisposable"/> then <see cref="SetShouldDispose"/> will be called to dispose the instance immediately.
@@ -133,7 +133,7 @@ namespace Media.Common
         ///  The sign bit of the integer value is the only 'confusing' part about this and it must be understood because the Interlocked methods are CLS Compliant and do not expose unsigned counterparts.
         ///  See the remarks section above for more clarity.
         /// </remarks>
-        private long State; // = Undisposed; (Todo, internal protected and can remove Statics.. or new private protected and...)
+        private int State; // = Undisposed; (Todo, internal protected and can remove Statics.. or new private protected and...)
 
         #endregion
 
@@ -188,9 +188,7 @@ namespace Media.Common
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             get
             {
-                //return System.Threading.Thread.VolatileRead(ref State) == Undisposed;
-                //return (System.Threading.Interlocked.Read(ref State) & int.MaxValue).Equals(Undisposed);
-                return System.Threading.Interlocked.Read(ref State).Equals(Undisposed);
+                return System.Threading.Volatile.Read(ref State) == Undisposed;
             }
         }
 
@@ -202,9 +200,7 @@ namespace Media.Common
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
             get
             {
-                //return System.Threading.Thread.VolatileRead(ref State) == Finalized;
-                //return (System.Threading.Interlocked.Read(ref State) & int.MaxValue).Equals(Finalized);
-                return System.Threading.Interlocked.Read(ref State).Equals(Finalized);
+                return System.Threading.Volatile.Read(ref State) == Finalized;
             }
         }
 

--- a/Common/Classes/Disposables/SuppressedFinalizerDisposable.cs
+++ b/Common/Classes/Disposables/SuppressedFinalizerDisposable.cs
@@ -55,7 +55,7 @@ namespace Media.Common
         internal void Resurrect(ref int managedThreadId)
         {
             //Need to retrieve the state from this instance.
-            long state = 0;
+            int state = 0;
 
             //Not already disposed or destructing?
             if (IsUndisposed is false | BaseDisposable.IsDestructing(this, ref state) is false) return;

--- a/Common/Collections/Generic/ConcurrentLinkedQueueSlim.cs
+++ b/Common/Collections/Generic/ConcurrentLinkedQueueSlim.cs
@@ -41,6 +41,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 #endregion
 
@@ -217,7 +218,7 @@ namespace Media.Common.Collections.Generic
         public bool IsEmpty
         {
             [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-            get { return Count is Common.Binary.LongZero; }
+            get { return Volatile.Read(ref First) is null; }
         }
 
         #endregion
@@ -324,8 +325,7 @@ namespace Media.Common.Collections.Generic
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public void Enqueue(T t)
         {
-            bool added = false;
-
+            bool added;
             do added = TryEnqueue(ref t);
             while (added is false);
         }

--- a/Common/Extensions/SocketExtensions.cs
+++ b/Common/Extensions/SocketExtensions.cs
@@ -963,15 +963,9 @@ namespace Media.Common.Extensions.Socket
 
         #region UnicastPortReuse
 
-        //Notes 4.6 has ReuseUnicastPort
-
-        private const int ReuseUnicastPort = 0x3007; // 12295
-
-        private static readonly System.Net.Sockets.SocketOptionName ReuseUnicastPortOption = (System.Net.Sockets.SocketOptionName)ReuseUnicastPort;
-
         public static void SetUnicastPortReuse(System.Net.Sockets.Socket socket, int value)
         {
-            socket.SetSocketOption(System.Net.Sockets.SocketOptionLevel.Socket, ReuseUnicastPortOption, value);
+            socket.SetSocketOption(System.Net.Sockets.SocketOptionLevel.Socket, System.Net.Sockets.SocketOptionName.ReuseUnicastPort, value);
         }
 
         public static void DisableUnicastPortReuse(System.Net.Sockets.Socket socket)

--- a/Http/HttpClient.cs
+++ b/Http/HttpClient.cs
@@ -1299,6 +1299,7 @@ namespace Media.Http
                 catch (Exception ex)
                 {
                     Common.ILoggingExtensions.Log(Logger, ToString() + "@SendHttpMessage: " + ex.Message);
+                    Common.ILoggingExtensions.LogException(Logger, ex);
                 }
                 finally
                 {

--- a/Rtp/RtpClient.Fields.cs
+++ b/Rtp/RtpClient.Fields.cs
@@ -56,6 +56,9 @@ namespace Media.Rtp
         internal bool m_StopRequested, m_ThreadEvents, //on or off right now, int could allow levels of threading..
             m_IListSockets; //Indicates if to use the IList send overloads.
 
+        // How much time to wait between event queue checks.
+        private System.TimeSpan m_WaitIntervalBetweenEvents = Media.Common.Extensions.TimeSpan.TimeSpanExtensions.OneMillisecond;
+
         //Collection to handle the dispatch of events.
         //Notes that Collections.Concurrent.Queue may be better suited for this in production until the ConcurrentLinkedQueue has been thoroughly engineered and tested.
         //The context, the item, final, recieved

--- a/Rtp/RtpClient.Fields.cs
+++ b/Rtp/RtpClient.Fields.cs
@@ -62,7 +62,7 @@ namespace Media.Rtp
         private readonly Media.Common.Collections.Generic.ConcurrentLinkedQueueSlim<(RtpClient.TransportContext Context, Common.BaseDisposable Packet, bool Final, bool Received)> m_EventData = new();
 
         //Todo, LinkedQueue and Clock.
-        private readonly System.Threading.ManualResetEventSlim m_EventReady = new(false, 100); //should be caluclated based on memory and speed. SpinWait uses 10 as a default.
+        private readonly System.Threading.ManualResetEventSlim m_EventReady = new(false, spinCount: 20); //should be caluclated based on memory and speed. SpinWait uses 10 as a default.
 
         //Outgoing Packets, Not a Queue because you cant re-order a Queue (in place) and you can't take a range from the Queue (in a single operation)
         //Those things aside, ordering is not performed here and only single packets are iterated and would eliminate the need for removing after the operation.

--- a/Rtp/RtpClient.Methods.cs
+++ b/Rtp/RtpClient.Methods.cs
@@ -2256,7 +2256,7 @@ namespace Media.Rtp
                             m_EventReady.Reset();
 
                             while (IsActive && m_EventData.IsEmpty)
-                                m_EventReady.Wait(Common.Extensions.TimeSpan.TimeSpanExtensions.OneMicrosecond);
+                                m_EventReady.Wait(WaitIntervalBetweenEvents);
                         }
                         else if (IsActive is false) break;
 

--- a/Rtp/RtpClient.Methods.cs
+++ b/Rtp/RtpClient.Methods.cs
@@ -2267,7 +2267,13 @@ namespace Media.Rtp
                         HandleEvent();
                     }
                 }
-                catch (System.Exception ex) { Media.Common.ILoggingExtensions.Log(Logger, ToString() + "@HandleEvents: " + ex.Message); goto Begin; }
+                catch (System.Exception ex)
+                {
+                    Media.Common.ILoggingExtensions.Log(Logger, ToString() + "@HandleEvents: " + ex.Message);
+                    Media.Common.ILoggingExtensions.LogException(Logger, ex);
+
+                    goto Begin;
+                }
             }
         }
 
@@ -2777,6 +2783,7 @@ namespace Media.Rtp
                 catch (System.Exception ex)
                 {
                     Media.Common.ILoggingExtensions.Log(Logger, ToString() + "@SendRecieve: " + ex.Message);
+                    Media.Common.ILoggingExtensions.LogException(Logger, ex);
 
                     if (critical) System.Threading.Thread.EndCriticalRegion();
 

--- a/Rtp/RtpClient.cs
+++ b/Rtp/RtpClient.cs
@@ -3913,6 +3913,19 @@ namespace Media.Rtp
         }
 
         /// <summary>
+        /// How much time to wait between event queue checks.
+        /// High values reduce event handling speed / FPS, but also reduce CPU consumption.
+        /// </summary>
+        public TimeSpan WaitIntervalBetweenEvents
+        {
+            [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.Synchronized | System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+            get => m_WaitIntervalBetweenEvents;
+
+            [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.Synchronized | System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+            set => m_WaitIntervalBetweenEvents = value;
+        }
+
+        /// <summary>
         /// Gets or sets a value which indicates if events will be threaded or not.
         /// If threading is enabled the call will block until the event thread has started.
         /// </summary>

--- a/Rtsp/RtspClient.cs
+++ b/Rtsp/RtspClient.cs
@@ -1019,6 +1019,7 @@ public class RtspClient : Common.SuppressedFinalizerDisposable, Media.Common.ISo
                 catch (Exception ex)
                 {
                     Media.Common.ILoggingExtensions.Log(Logger, ToString() + "@IsPlaying - " + ex.Message);
+                    Media.Common.ILoggingExtensions.LogException(Logger, ex);
                 }
             }
 
@@ -3083,7 +3084,7 @@ public class RtspClient : Common.SuppressedFinalizerDisposable, Media.Common.ISo
     public void StopPlaying(bool disconnectSocket = true)
     {
         try { Disconnect(disconnectSocket); }
-        catch (Exception ex) { Media.Common.ILoggingExtensions.Log(Logger, ex.Message); }
+        catch (Exception ex) { Media.Common.ILoggingExtensions.LogException(Logger, ex); }
     }
 
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.Synchronized)]
@@ -3318,7 +3319,7 @@ public class RtspClient : Common.SuppressedFinalizerDisposable, Media.Common.ISo
         }
         catch (Exception ex)
         {
-            Common.ILoggingExtensions.Log(Logger, ex.Message);
+            Common.ILoggingExtensions.LogException(Logger, ex);
 
             throw;
         }
@@ -4623,6 +4624,7 @@ public class RtspClient : Common.SuppressedFinalizerDisposable, Media.Common.ISo
             catch (Exception ex)
             {
                 Common.ILoggingExtensions.Log(Logger, ToString() + "@SendRtspMessage: " + ex.Message);
+                Common.ILoggingExtensions.LogException(Logger, ex);
             }
             finally
             {
@@ -5967,7 +5969,11 @@ public class RtspClient : Common.SuppressedFinalizerDisposable, Media.Common.ISo
                     DisableKeepAliveRequest = keepAlives;
                 }
             }
-            catch (Exception ex) { Common.ILoggingExtensions.Log(Logger, ToString() + "@MonitorProtocol: " + ex.Message); }
+            catch (Exception ex)
+            {
+                Common.ILoggingExtensions.Log(Logger, ToString() + "@MonitorProtocol: " + ex.Message);
+                Common.ILoggingExtensions.LogException(Logger, ex);
+            }
 
             //If not disposed AND IsConnected and if protocol switch is still allowed AND IsPlaying and not already TCP
             if (Common.IDisposedExtensions.IsNullOrDisposed(this) is false &&
@@ -6047,6 +6053,7 @@ public class RtspClient : Common.SuppressedFinalizerDisposable, Media.Common.ISo
                     catch (Exception ex)
                     {
                         Common.ILoggingExtensions.Log(Logger, ToString() + "@MonitorProtocol: " + ex.Message);
+                        Common.ILoggingExtensions.LogException(Logger, ex);
                     }
                 }
             }
@@ -6070,8 +6077,19 @@ public class RtspClient : Common.SuppressedFinalizerDisposable, Media.Common.ISo
 
         //If there is still a timer change it based on the last messages round trip time, should be relative to all messages...
         if (Common.IDisposedExtensions.IsNullOrDisposed(this) is false && m_ProtocolMonitor is not null)
-            try { m_ProtocolMonitor.Change(m_ConnectionTime.Add(LastMessageRoundTripTime), Media.Common.Extensions.TimeSpan.TimeSpanExtensions.InfiniteTimeSpan); }
-            catch (Exception ex) { Common.ILoggingExtensions.Log(Logger, ToString() + "@MonitorProtocol: " + ex.Message); }
+            try
+            {
+                m_ProtocolMonitor.Change
+                (
+                    m_ConnectionTime.Add(LastMessageRoundTripTime),
+                    Media.Common.Extensions.TimeSpan.TimeSpanExtensions.InfiniteTimeSpan
+                );
+            }
+            catch (Exception ex)
+            {
+                Common.ILoggingExtensions.Log(Logger, ToString() + "@MonitorProtocol: " + ex.Message);
+                Common.ILoggingExtensions.LogException(Logger, ex);
+            }
     }
 
     public RtspMessage SendPlay(MediaDescription mediaDescription, TimeSpan? startTime = null, TimeSpan? endTime = null, string rangeType = "npt")
@@ -6514,7 +6532,11 @@ public class RtspClient : Common.SuppressedFinalizerDisposable, Media.Common.ISo
             }
 
         }
-        catch (Exception ex) { Common.ILoggingExtensions.Log(Logger, ToString() + "@SendKeepAlive: " + ex.Message); }
+        catch (Exception ex)
+        {
+            Common.ILoggingExtensions.Log(Logger, ToString() + "@SendKeepAlive: " + ex.Message);
+            Common.ILoggingExtensions.LogException(Logger, ex);
+        }
 
         //Raise the stopping event if not playing anymore
         //if (true == wasPlaying && false == IsPlaying) OnStopping();

--- a/Rtsp/RtspSession.cs
+++ b/Rtsp/RtspSession.cs
@@ -752,6 +752,7 @@ namespace Media.Rtsp
                     catch (Exception ex)
                     {
                         Media.Common.ILoggingExtensions.Log(Logger, ToString() + "@IsPlaying - " + ex.Message);
+                        Media.Common.ILoggingExtensions.LogException(Logger, ex);
                     }
                 }
 
@@ -1702,6 +1703,7 @@ namespace Media.Rtsp
                 catch (Exception ex)
                 {
                     Common.ILoggingExtensions.Log(Logger, ToString() + "@SendRtspMessage: " + ex.Message);
+                    Common.ILoggingExtensions.LogException(Logger, ex);
                 }
                 finally
                 {
@@ -2399,7 +2401,7 @@ namespace Media.Rtsp
             }
             catch (Exception ex)
             {
-                Common.ILoggingExtensions.Log(Logger, ex.Message);
+                Common.ILoggingExtensions.LogException(Logger, ex);
 
                 throw;
             }

--- a/RtspServer/MediaTypes/RFC2435Media.cs
+++ b/RtspServer/MediaTypes/RFC2435Media.cs
@@ -2527,7 +2527,7 @@ namespace Media.Rtsp.Server.MediaTypes
                 {
                     try
                     {
-                        if (Frames.Count is 0 && State == StreamState.Started)
+                        if (Frames.IsEmpty && State == StreamState.Started)
                         {
                             if (RtpClient.IsActive) RtpClient.m_WorkerThread.Priority = System.Threading.ThreadPriority.Lowest;
 

--- a/RtspServer/MediaTypes/RtpAudioSink.cs
+++ b/RtspServer/MediaTypes/RtpAudioSink.cs
@@ -68,7 +68,7 @@ public class RtpAudioSink : RtpSink
             {
                 try
                 {
-                    if (Frames.Count is 0 && State == StreamState.Started)
+                    if (Frames.IsEmpty && State == StreamState.Started)
                     {
                         if (RtpClient.IsActive) RtpClient.m_WorkerThread.Priority = System.Threading.ThreadPriority.Lowest;
 

--- a/RtspServer/MediaTypes/RtpSink.cs
+++ b/RtspServer/MediaTypes/RtpSink.cs
@@ -155,7 +155,7 @@ namespace Media.Rtsp.Server.MediaTypes
             {
                 try
                 {
-                    if (Packets.Count is 0)
+                    if (Packets.IsEmpty)
                     {
                         System.Threading.Thread.Sleep(0);
 

--- a/RtspServer/MediaTypes/RtpVideoSink.cs
+++ b/RtspServer/MediaTypes/RtpVideoSink.cs
@@ -188,7 +188,7 @@ public class RtpVideoSink : RtpSink
         {
             try
             {
-                if (Frames.Count is 0 && State is StreamState.Started)
+                if (Frames.IsEmpty && State is StreamState.Started)
                 {
                     if (RtpClient.IsActive)
                         RtpClient.m_WorkerThread.Priority = ThreadPriority.Lowest;

--- a/RtspServer/RtspServer.cs
+++ b/RtspServer/RtspServer.cs
@@ -646,16 +646,16 @@ namespace Media.Rtsp
         //Todo
         //Allow for joining of server instances to support multiple end points.
 
-        public RtspServer(AddressFamily addressFamily = AddressFamily.InterNetwork, int listenPort = DefaultPort, bool shouldDispose = true)
-            : this(new IPEndPoint(Media.Common.Extensions.Socket.SocketExtensions.GetFirstUnicastIPAddress(addressFamily), listenPort), shouldDispose) { }
+        public RtspServer(AddressFamily addressFamily, int listenPort, TimeSpan? inactivityTimeout = null, bool shouldDispose = true)
+            : this(new IPEndPoint(Media.Common.Extensions.Socket.SocketExtensions.GetFirstUnicastIPAddress(addressFamily), listenPort), inactivityTimeout, shouldDispose) { }
 
-        public RtspServer(IPAddress listenAddress, int listenPort, bool shouldDispose = true)
-            : this(new IPEndPoint(listenAddress, listenPort), shouldDispose) { }
+        public RtspServer(IPAddress listenAddress, int listenPort, TimeSpan? inactivityTimeout = null, bool shouldDispose = true)
+            : this(new IPEndPoint(listenAddress, listenPort), inactivityTimeout, shouldDispose) { }
 
-        public RtspServer(IPEndPoint listenEndPoint, bool shouldDispose = true)
+        public RtspServer(IPEndPoint listenEndPoint, TimeSpan? inactivityTimeout = null, bool shouldDispose = true)
             : base(shouldDispose)
         {
-            RtspClientInactivityTimeout = TimeSpan.FromSeconds(60);
+            RtspClientInactivityTimeout = inactivityTimeout ?? TimeSpan.FromSeconds(60);
 
             //Check syntax of Server header to ensure allowed format...
             ServerName = "ASTI Media Server RTSP\\" + Version.ToString(RtspMessage.VersionFormat, System.Globalization.CultureInfo.InvariantCulture);

--- a/RtspServer/RtspServer.cs
+++ b/RtspServer/RtspServer.cs
@@ -255,16 +255,34 @@ namespace Media.Rtsp
         private Thread m_ServerThread;
 
         /// <summary>
-        /// Indicates to the ServerThread a stop has been requested
+        /// Indicates to the ServerThread a stop has been requested.
         /// </summary>
-        private bool m_StopRequested, m_Maintaining;
+        private int m_StopRequested, m_Maintaining;
 
         //Handles the Restarting of streams which needs to be and disconnects clients which are inactive.
-        internal Timer m_Maintainer;
+        internal volatile Timer m_Maintainer;
 
         #endregion
 
         #region Propeties
+
+        /// <summary>
+        /// Is stop requested? Thread-safe as required.
+        /// </summary>
+        private bool IsStopRequested
+        {
+            get => Volatile.Read(ref m_StopRequested) == 1;
+            set => Interlocked.Exchange(ref m_StopRequested, value ? 1 : 0);
+        }
+
+        /// <summary>
+        /// Is maintaining server? Thread-safe as required.
+        /// </summary>
+        private bool IsMaintaining
+        {
+            get => Volatile.Read(ref m_Maintaining) == 1;
+            set => Interlocked.Exchange(ref m_Maintaining, value ? 1 : 0);
+        }
 
         public Media.Rtsp.Server.RtspStreamArchiver Archiver
         {
@@ -427,7 +445,7 @@ namespace Media.Rtsp
             get
             {
                 return IsDisposed is false &&
-                    m_StopRequested is false &&
+                    IsStopRequested is false &&
                     m_Started.HasValue &&
                     m_ServerThread is not null;
             }
@@ -1210,7 +1228,7 @@ namespace Media.Rtsp
             if (IsRunning) return;
 
             //Allowed to run
-            m_Maintaining = m_StopRequested = false;
+            IsMaintaining = IsStopRequested = false;
 
             //Indicate start was called
             Common.ILoggingExtensions.Log(Logger, "Server Started @ " + DateTime.UtcNow);
@@ -1262,7 +1280,7 @@ namespace Media.Rtsp
             //Start it
             m_ServerThread.Start();
 
-            //Timer for maintaince ( one quarter of the ticks)
+            //Timer for maintaince (one quarter of the ticks)
             m_Maintainer = new Timer(MaintainServer,
                 null,
                 TimeSpan.FromTicks(RtspClientInactivityTimeout.Ticks >> 2),
@@ -1290,11 +1308,11 @@ namespace Media.Rtsp
         /// <param name="state">Reserved</param>
         internal virtual void MaintainServer(object state = null)
         {
-            if (m_Maintaining || IsDisposed || m_StopRequested) return;
+            if (IsMaintaining || IsDisposed || IsStopRequested) return;
 
-            if (IsRunning && m_Maintaining is false)
+            if (IsRunning && IsMaintaining is false)
             {
-                m_Maintaining = true;
+                IsMaintaining = true;
 
                 try
                 {
@@ -1315,7 +1333,7 @@ namespace Media.Rtsp
 
                         MediaStreams.AsParallel().ForAll(s => s.TrySetLogger(Logger));
 
-                        m_Maintaining = false;
+                        IsMaintaining = false;
 
                         if (IsRunning && m_Maintainer is not null)
                         {
@@ -1336,7 +1354,7 @@ namespace Media.Rtsp
                 {
                     Common.ILoggingExtensions.LogException(Logger, ex);
 
-                    m_Maintaining = m_Maintainer is not null;
+                    IsMaintaining = m_Maintainer is not null;
                 }
             }
         }
@@ -1353,7 +1371,7 @@ namespace Media.Rtsp
             if (IsRunning is false) return;
 
             //Stop listening for new clients
-            m_StopRequested = true;
+            IsStopRequested = true;
 
             Common.ILoggingExtensions.Log(Logger, "@Stop - StopRequested");
             Common.ILoggingExtensions.Log(Logger, "Connected Clients:" + ActiveConnections);
@@ -1415,7 +1433,7 @@ namespace Media.Rtsp
 
             foreach (Media.Rtsp.Server.IMedia stream in MediaStreams)
             {
-                if (m_StopRequested) return;
+                if (IsStopRequested) return;
 
                 streamTasks.Add(StartStreamAsync(stream));
             }
@@ -1509,9 +1527,10 @@ namespace Media.Rtsp
                 //While running
                 while (IsRunning)
                 {
-                    if (m_StopRequested)
+                    if (IsStopRequested)
                         break;
-                    else if (m_Sessions.Count < m_MaximumSessions)
+
+                    if (m_Sessions.Count < m_MaximumSessions)
                     {
                         //If not already accepting
                         if (lastAccept is null)
@@ -1560,7 +1579,7 @@ namespace Media.Rtsp
             {
                 Common.ILoggingExtensions.LogException(Logger, ex);
 
-                if (m_StopRequested) return;
+                if (IsStopRequested) return;
 
                 goto Begin;
             }
@@ -2245,7 +2264,7 @@ namespace Media.Rtsp
                 //Then it would also be easier to make /audio only passwords etc.
 
                 //When stopping only handle teardown and keep alives
-                if (m_StopRequested &&
+                if (IsStopRequested &&
                     (request.ContainsHeader(RtspHeaders.Connection) is false ||
                     (request.RtspMethod != RtspMethod.TEARDOWN && request.RtspMethod != RtspMethod.GET_PARAMETER && request.RtspMethod != RtspMethod.OPTIONS)))
                 {

--- a/UnitTests/Program.cs
+++ b/UnitTests/Program.cs
@@ -144,15 +144,15 @@ namespace Media.UnitTests
         public static async Task Main(string[] args)
         {
             //Run the main tests
-            foreach (Action test in LogicTests) RunTest(test);
+            //foreach (Action test in LogicTests) RunTest(test);
 
-            Console.WriteLine("Logic Tests Complete! Press Q to Exit or any other key to perform the live tests.");
+            //Console.WriteLine("Logic Tests Complete! Press Q to Exit or any other key to perform the live tests.");
 
-            if (Console.ReadKey(true).Key == ConsoleKey.Q) return;
+            //if (Console.ReadKey(true).Key == ConsoleKey.Q) return;
 
-            RunTest(HttpClientTests);
+            //RunTest(HttpClientTests);
 
-            RunTest(RtspClientTests);
+            //RunTest(RtspClientTests);
 
             await RunTestAsync(TestServerAsync, nameof(TestServerAsync)).ConfigureAwait(false);
         }
@@ -2470,10 +2470,6 @@ namespace Media.UnitTests
                                     catch (Exception ex)
                                     {
                                         server.Logger.LogException(ex);
-
-                                        gfxScreenshot.Dispose();
-
-                                        bmpScreenshot.Dispose();
 
                                         if (server is not null && server.IsRunning) goto Start;
                                     }


### PR DESCRIPTION
* Allow to configure RTSP client inactivity timeouts for server streams.
* Use .net core way to enable unicast port reuse for socket.
* Thread-safe access to state shared between server and maintaining threads.
* Disposable uses `Interlocked` API and `int` to speedup on old x86 32 bit architecture.
* Do not busy wait for 100 cycles during waiting for events. It is too long and consumes CPU time.
* Speedup thread-safe empty queue checks.
* Do not wait for events in queue for 1 microsecond. There are no streams with 1000000 * N FPS and such small wait time creates unneeded CPU load. Allow to configure how much time to wait and use 1 millisecond as default.
* Do not lose exception stack traces in logs. Hard to debug issues when no stack traces. 